### PR TITLE
KT1-162: feat(internal-api): 내부 서비스용 API 엔드포인트 및 헬퍼 추가

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -6,6 +6,7 @@ from app.config.config import config_by_name
 from app.utils.logger import Logger
 from app.common.response import register_error_handlers
 from app.api import router as api_router
+from app.api.internal_router import router as internal_api_router # internal_router 임포트
 import os
 
 def create_app(config_name):
@@ -95,6 +96,7 @@ def create_app(config_name):
         return {"status": "ok", "service": "story-api", "port": 8011}
     
     app.include_router(api_router, prefix=config.APP_PREFIX)
+    app.include_router(internal_api_router) # 내부 API 라우터 포함
     register_error_handlers(app)
     
     return app
@@ -104,4 +106,4 @@ def load_dynamic_config(config):
     return None
 
 # 환경변수로 CORE_MODULES_AVAILABLE 설정
-CORE_MODULES_AVAILABLE = os.getenv('CORE_MODULES_AVAILABLE', 'true').lower() == 'true' 
+CORE_MODULES_AVAILABLE = os.getenv('CORE_MODULES_AVAILABLE', 'true').lower() == 'true'

--- a/app/api/internal_router.py
+++ b/app/api/internal_router.py
@@ -1,0 +1,42 @@
+from fastapi import APIRouter, Depends, HTTPException, status, Request
+from sqlalchemy.orm import Session
+from typing import List, Optional
+from app.common.response import create_response
+from app.helper.story_helper import get_internal_stories_helper # 새로운 헬퍼 함수 임포트
+from app.schemas.story import StoryResponse
+from app.database import get_db
+from app.models.story import Story # Story 모델 임포트
+import logging
+from datetime import datetime
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(
+    prefix="/internal",
+    tags=["Internal Synchronization"]
+)
+
+@router.get("/stories", description="내부 서비스용 이야기 목록 조회 (인증 없음)")
+async def get_internal_stories(
+    request: Request,
+    updated_after: Optional[str] = None, # dify-data-sync-service에서 사용할 파라미터
+    skip: int = 0, 
+    limit: int = 100, 
+    db: Session = Depends(get_db)
+):
+    """인증 없이 내부 서비스가 이야기 목록을 조회합니다."""
+    logger.info(f"Internal story fetch triggered. updated_after: {updated_after}")
+    
+    stories = get_internal_stories_helper(db, skip=skip, limit=limit, updated_after=updated_after)
+    
+    return create_response([StoryResponse.model_validate(story.__dict__) for story in stories])
+
+@router.get("/story-ids", description="내부 서비스용 모든 이야기 ID 목록 조회 (인증 없음)")
+async def get_all_story_ids(
+    db: Session = Depends(get_db)
+):
+    """인증 없이 내부 서비스가 모든 이야기의 ID 목록을 조회합니다."""
+    logger.info("Internal story ID fetch triggered.")
+    
+    story_ids = db.query(Story.id).all()
+    return create_response([story_id[0] for story_id in story_ids])

--- a/app/helper/story_helper.py
+++ b/app/helper/story_helper.py
@@ -3,6 +3,9 @@ from app.utils.functions import validate_story_content, validate_story_title
 from app.common.response import ValidationError
 from fastapi import Request
 import logging
+from sqlalchemy.orm import Session
+from datetime import datetime
+from app.models.story import Story # Story 모델 임포트
 
 logger = logging.getLogger(__name__)
 
@@ -85,4 +88,18 @@ def delete_story_helper(request: Request, story_id):
         
     except Exception as e:
         logger.error(f"Error in delete_story_helper: {e}")
-        raise 
+        raise
+
+def get_internal_stories_helper(db: Session, skip: int = 0, limit: int = 100, updated_after: str = None):
+    """내부 서비스용 이야기 목록 조회 헬퍼 (updated_after 필터링 포함)"""
+    try:
+        query = db.query(Story)
+        if updated_after:
+            updated_after_dt = datetime.fromisoformat(updated_after)
+            query = query.filter(Story.updated_at >= updated_after_dt)
+        
+        return query.offset(skip).limit(limit).all()
+        
+    except Exception as e:
+        logger.error(f"Error in get_internal_stories_helper: {e}")
+        raise


### PR DESCRIPTION
- `app/api/internal_router.py` 파일 신규 생성: 내부 서비스(dify-data-sync-service)를 위한 전용 API 라우터 추가.
  - `/internal/stories` 엔드포인트 추가: `updated_after`, `skip`, `limit` 파라미터를 사용하여 스토리 목록을 직접 조회하도록 구현.
  - `/internal/story-ids` 엔드포인트 추가: 현재 존재하는 모든 이야기의 ID 목록을 반환하도록 구현.
  - 이 엔드포인트들은 인증 없이 접근 가능하도록 설정.
- `app/__init__.py` 파일 수정: `internal_router`를 FastAPI 애플리케이션에 포함.
- `app/helper/story_helper.py` 파일 수정: `internal_router`에서 사용할 `get_internal_stories_helper` 함수를 새로 추가하여 `updated_after` 필터링 로직을 포함.
  - 기존 `get_stories_helper` 함수는 변경하지 않고, 내부 서비스용 헬퍼를 분리하여 구현.